### PR TITLE
Docker Setup on Heroku

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,19 @@
+FROM --platform=linux/amd64 node:14.17.0-alpine
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+COPY tsconfig.json .
+
+RUN npm install
+RUN npm ci --only=production
+
+COPY . .
+
+RUN npm run build
+
+# required for docker desktop port mapping
+EXPOSE 3000
+
+CMD ["npx", "serve", "build"]

--- a/client/Dockerfile.web
+++ b/client/Dockerfile.web
@@ -1,0 +1,21 @@
+FROM --platform=linux/amd64 node:14.17.0-alpine
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+COPY tsconfig.json .
+
+RUN npm install
+RUN npm ci --only=production
+
+COPY . .
+
+RUN npm run build
+
+ENV NODE_ENV=production
+
+# required for docker desktop port mapping
+EXPOSE 3000
+
+CMD ["npx", "serve", "build"]

--- a/client/src/apis/AlgoFetcher.js
+++ b/client/src/apis/AlgoFetcher.js
@@ -9,7 +9,7 @@ import axios from "axios";
 // URL based on NODE_ENV
 
 const baseURL =
-    process.env.NODE_ENV === "production" ? "api" : "http://localhost:3001/api";
+    process.env.NODE_ENV === "production" ? "https://algo-viz-server.herokuapp.com/api" : "http://localhost:3001/api";
 
 export default axios.create({
     baseURL,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3.8"
+services:
+  client:
+    build: ./client
+    depends_on:
+      - server
+    container_name: algo-viz-client
+    ports:
+      - '3000:3000'
+    stdin_open: true
+    tty: true
+  server:
+    build: ./server
+    container_name: algo-viz-server
+    ports:
+      - '3001:3001'
+    volumes:
+      - ./server:/app
+      - /app/node_modules

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,19 @@
+FROM --platform=linux/amd64 node:14.17.0-alpine
+
+RUN npm install -g nodemon
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+COPY tsconfig.json .
+
+RUN npm install
+RUN npm ci --only=production
+
+COPY . .
+
+# required for docker desktop port mapping
+EXPOSE 3001
+
+CMD ["npm", "start"]

--- a/server/Dockerfile.web
+++ b/server/Dockerfile.web
@@ -1,0 +1,19 @@
+FROM --platform=linux/amd64 node:14.17.0-alpine
+
+RUN npm install -g nodemon
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+COPY tsconfig.json .
+
+RUN npm install
+RUN npm ci --only=production
+
+COPY . .
+
+# required for docker desktop port mapping
+EXPOSE 3001
+
+CMD ["npm", "start"]


### PR DESCRIPTION
There are two sets of files that are important:

Development:
- The files `client/Dockerfile` and `server/Dockerfile` and `docker-compose.yaml` are there to allow you to build Docker containers and deploy code **locally**. 
- Once you have Docker installed and have a Docker account, run the command `docker compose up` at the root directory. This will use `docker-compose.yaml` to build and deploy the code using `client/Dockerfile` and `server/Dockerfile`.

Production:
- The files `client/Dockerfile.web` and `server/Dockerfile.web` are used when deploying to Heroku. The website is currently deployed to Vikram Nithyanandam's personal Heroku account. 
- The client codebase is deployed to the `algo-viz-client` Heroku app and appears [here](https://algo-viz-client.herokuapp.com/) while the server codebase is deployed to `algo-viz-server` and deployed [here](https://algo-viz-server.herokuapp.com/api).
- The `AlgoFetcher.js` file was slightly changed to query the hosted back-end backend code from Heroku when its in production.