### PR TITLE
75 fix backend testing

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -9,10 +9,11 @@
 /coverage
 
 # production
-# /build
+/build
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/client/src/components/Graph/index.tsx
+++ b/client/src/components/Graph/index.tsx
@@ -349,7 +349,6 @@ const Graph = ({
                 </g>
                 <g className="nodes">
                     {nodes.map((nodeId) => {
-                        console.log(nodeId);
                         return nodeId != null ? (
                             <Draggable
                                 onDrag={(e, data) => {

--- a/client/src/components/GraphControls/index.tsx
+++ b/client/src/components/GraphControls/index.tsx
@@ -169,7 +169,6 @@ const GraphControls = ({
         }
 
         if (nodeId == '-Select Node-') {
-          console.log("I went into here!");
           let error = "Please enter in a value" as string
           alertMessage(document.getElementById("removeNodePortion") as HTMLDivElement, error)
           return;
@@ -246,7 +245,6 @@ const GraphControls = ({
       let endCheck = "End" as string;
 
       if (startValue == startCheck || endValue == endCheck) {
-        console.log("I went into here!");
         let error = "Please enter in a value" as string
         alertMessage(document.getElementById("removeEdgePortion") as HTMLDivElement, error)
         return;

--- a/client/src/components/Queue/index.tsx
+++ b/client/src/components/Queue/index.tsx
@@ -45,8 +45,6 @@ const Queue = ({ ...props }) => {
     const temp = currentIndex
     currentIndex = currentStep;
 
-    console.log("Past index: " + temp);
-    console.log("Current index: " + newStep);
     return (
         <div className="queueBack-container">
             <div className="text-queue">

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2677,9 +2677,9 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -5879,9 +5879,9 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
         },
         "kleur": {
             "version": "3.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "./build/index.js",
     "scripts": {
-        "test": "jest --coverage",
+        "test": "jest build --coverage",
         "start": "node ./build/index.js",
         "build": "tsc"
     },
@@ -19,5 +19,8 @@
         "jest": "^28.1.3",
         "pg": "^8.7.3",
         "typescript": "^4.8.2"
+    },
+    "jest": {
+        "verbose": true
     }
 }

--- a/server/src/algorithms/searches.test.js
+++ b/server/src/algorithms/searches.test.js
@@ -1,5 +1,9 @@
 const { linearSearch, binarySearch, depthFirstSearch } = require("./searches");
 
+test("Fake test", () => {
+    expect(1).toEqual(1);
+})
+
 test("Linear Search basic cases", () => {
     // a success case
     let array = [1, 2, 3];
@@ -110,7 +114,7 @@ test("Binary Search edge cases", () => {
 });
 
 test("Depth First Search basic cases", () => {
-    let nodes = [0, 1, 2, 3, 4, 5, 6];
+    let nodes = ["0", "1", "2", "3", "4", "5", "6"];
     let edges = [
         { n1: 0, n2: 1 },
         { n1: 0, n2: 2 },
@@ -121,7 +125,7 @@ test("Depth First Search basic cases", () => {
     ];
 
     let result = depthFirstSearch(nodes, edges, 0).traversalResult;
-    expect(result).toEqual([0, 1, 3, 4, 5, 2, 6]);
+    expect(result).toEqual(["0", "1", "3", "4", "5", "2", "6"]);
 });
 
 test("Depth First Search edge cases", () => {
@@ -129,7 +133,7 @@ test("Depth First Search edge cases", () => {
     let nodes = [];
     let edges = [];
 
-    let result = depthFirstSearch(nodes, edges, 0);
+    let result = depthFirstSearch(nodes, edges, 0).traversalResult;
     expect(result).toEqual([]);
 
     // 1 element graph
@@ -137,5 +141,5 @@ test("Depth First Search edge cases", () => {
     edges = [];
 
     result = depthFirstSearch(nodes, edges, 0).traversalResult;
-    expect(result).toEqual([0]);
+    expect(result).toEqual(["0"]);
 });

--- a/server/src/algorithms/searches.test.js
+++ b/server/src/algorithms/searches.test.js
@@ -1,4 +1,4 @@
-const { linearSearch, binarySearch, depthFirstSearch } = require("./searches");
+const { linearSearch, binarySearch, depthFirstSearch, breadthFirstSearch } = require("./searches");
 
 test("Fake test", () => {
     expect(1).toEqual(1);

--- a/server/src/algorithms/searches.test.js
+++ b/server/src/algorithms/searches.test.js
@@ -1,9 +1,5 @@
 const { linearSearch, binarySearch, depthFirstSearch, breadthFirstSearch } = require("./searches");
 
-test("Fake test", () => {
-    expect(1).toEqual(1);
-})
-
 test("Linear Search basic cases", () => {
     // a success case
     let array = [1, 2, 3];

--- a/server/src/algorithms/searches.test.js
+++ b/server/src/algorithms/searches.test.js
@@ -116,16 +116,31 @@ test("Binary Search edge cases", () => {
 test("Depth First Search basic cases", () => {
     let nodes = ["0", "1", "2", "3", "4", "5", "6"];
     let edges = [
-        { n1: 0, n2: 1 },
-        { n1: 0, n2: 2 },
-        { n1: 1, n2: 3 },
-        { n1: 1, n2: 4 },
-        { n1: 4, n2: 5 },
-        { n1: 2, n2: 6 },
+        { n1: "0", n2: "1" },
+        { n1: "0", n2: "2" },
+        { n1: "1", n2: "3" },
+        { n1: "1", n2: "4" },
+        { n1: "4", n2: "5" },
+        { n1: "2", n2: "6" }
     ];
 
     let result = depthFirstSearch(nodes, edges, 0).traversalResult;
     expect(result).toEqual(["0", "1", "3", "4", "5", "2", "6"]);
+});
+
+test("Breadth First Search basic cases", () => {
+    let nodes = ["0", "1", "2", "3", "4", "5", "6"];
+    let edges = [
+        { n1: "0", n2: "1" },
+        { n1: "0", n2: "2" },
+        { n1: "1", n2: "3" },
+        { n1: "1", n2: "4" },
+        { n1: "4", n2: "5" },
+        { n1: "2", n2: "6" }
+    ];
+
+    let result = breadthFirstSearch(nodes, edges, 0).traversalResult;
+    expect(result).toEqual(["0", "1", "2", "3", "4", "6", "5"]);
 });
 
 test("Depth First Search edge cases", () => {
@@ -143,3 +158,20 @@ test("Depth First Search edge cases", () => {
     result = depthFirstSearch(nodes, edges, 0).traversalResult;
     expect(result).toEqual(["0"]);
 });
+
+test("Breadth First Search edge cases", () => {
+    // empty graph
+    let nodes = [];
+    let edges = [];
+
+    let result = breadthFirstSearch(nodes, edges, 0).traversalResult;
+    expect(result).toEqual([]);
+
+    // 1 element graph
+    nodes = [0];
+    edges = [];
+
+    result = breadthFirstSearch(nodes, edges, 0).traversalResult;
+    expect(result).toEqual(["0"]);
+});
+


### PR DESCRIPTION
**Problem**: The backend was failing DFS tests and 2 suite tests, see Issue #75 for how that looked. 
**Solution**: The backend DFS function accepted input in the form of stringified numbers, not just numbers. However, the tests were providing regular numbers rather than string integers to the backend functions, which caused the error. Along with that, a couple of the other tests were faultily written and needed to be fixed.

For the suite tests, it turned out our testing library (Jest) was running test files that were in Typescript in addition to the compiled test files that were under the `build` folder, so it was a quick fix to just have Jest only run build file test folders.

**Additional Modifications**: I added tests for BFS as well since our codebase was lacking and updated the front-end `.gitignore` file to ignore `build` and `.env`